### PR TITLE
Changes made to tick marks on time series charts.

### DIFF
--- a/Data-Explorer/server.R
+++ b/Data-Explorer/server.R
@@ -192,13 +192,12 @@ output$trend_plot <- renderPlotly({
              xaxis = list(fixedrange = FALSE,
                           title = "Quarter",
                           type = "date",
-                          nticks = length(unique(data_trend_plot()$quarter_name)),
-                          ticktext = data_trend_plot()$quarter_name, 
+                          ticktext = data_trend_plot()$quarter_name,
                           tickvals = data_trend_plot()$quarter_end,
-                          tickmode = "array"),
+                          tickmode = "array",
+                          tickangle = -45),
              shapes = list(vline(x=dmy("30-03-2020"))),
-             annotations = list(covid_label,covid_arrow)) %>% 
-
+             annotations = list(covid_label,covid_arrow)) %>%
       
       # Remove unnecessary buttons from the modebar.
       config(displayModeBar = TRUE,
@@ -386,12 +385,12 @@ output$trend_plot_2 <- renderPlotly({
         xaxis = list(fixedrange = FALSE,
                      title = "Quarter",
                      type = "date",
-                     nticks = length(unique(data_trend_plot_2()$quarter_name)),
                      ticktext = data_trend_plot_2()$quarter_name, 
                      tickvals = data_trend_plot_2()$quarter_end,
-                     tickmode = "array"),
+                     tickmode = "array",
+                     tickangle = -45),
         shapes = list(vline(x=dmy("30-03-2020"))),
-        annotations = list(covid_label,covid_arrow)) %>% 
+        annotations = list(covid_label,covid_arrow)) %>%
       
       # Remove unnecessary buttons from the modebar.
       config(displayModeBar = TRUE,


### PR DESCRIPTION
Hi John,

As discussed earlier, I've made some improvements to the tick marks on the time series charts. They should now behave themselves on smaller screens (or in minimised windows) with the angle set to 45 degrees. The 'nticks' lines are also redundant when using mode 'array' for the ticks. Otherwise I just removed some white space before lines 200 and 393.

Thanks,

James